### PR TITLE
Lazily apply window options

### DIFF
--- a/internal/dialog/input.go
+++ b/internal/dialog/input.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"image"
 	"image/color"
+	"sync"
 	"time"
 
 	"gioui.org/app"
@@ -142,10 +143,12 @@ func (d *inputDialog) Show() (string, bool, error) {
 		app.Title(d.Title),
 		app.Size(unit.Dp(d.Width), unit.Dp(d.Height)),
 	)
-	go func() {
+	// TODO work around https://todo.sr.ht/~eliasnaur/gio/602 (still an issue in gio v0.8.0?)
+	// this should only be required shortly after creating the window w.
+	applyWindowOptions := sync.OnceFunc(func() {
 		time.Sleep(50 * time.Millisecond)
 		w.Perform(system.ActionCenter | system.ActionRaise)
-	}()
+	})
 	w.Perform(system.ActionCenter | system.ActionRaise)
 
 	th := material.NewTheme()
@@ -154,6 +157,7 @@ func (d *inputDialog) Show() (string, bool, error) {
 	for !d.done {
 		switch e := w.Event().(type) {
 		case app.FrameEvent:
+			applyWindowOptions()
 			gtx := app.NewContext(&ops, e)
 			if d.cancelButton.Clicked(gtx) {
 				d.handleCancel()

--- a/internal/dialog/select.go
+++ b/internal/dialog/select.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"image"
 	"image/color"
+	"sync"
 	"time"
 
 	"gioui.org/app"
@@ -165,10 +166,12 @@ func (d *selectDialog) Show() (string, bool, error) {
 		app.Title(d.Title),
 		app.Size(unit.Dp(d.Width), unit.Dp(d.Height)),
 	)
-	go func() {
+	// TODO work around https://todo.sr.ht/~eliasnaur/gio/602 (still an issue in gio v0.8.0?)
+	// this should only be required shortly after creating the window w.
+	applyWindowOptions := sync.OnceFunc(func() {
 		time.Sleep(50 * time.Millisecond)
 		w.Perform(system.ActionCenter | system.ActionRaise)
-	}()
+	})
 	w.Perform(system.ActionCenter | system.ActionRaise)
 
 	th := material.NewTheme()
@@ -177,6 +180,7 @@ func (d *selectDialog) Show() (string, bool, error) {
 	for !d.done {
 		switch e := w.Event().(type) {
 		case app.FrameEvent:
+			applyWindowOptions()
 			gtx := app.NewContext(&ops, e)
 			if d.cancelButton.Clicked(gtx) {
 				d.handleCancel()


### PR DESCRIPTION
Works around https://todo.sr.ht/~eliasnaur/gio/602 (still an issue in gio v0.8.0?). This should only be required shortly after creating the window w.