### PR TITLE
Fix ActionCenter on macOS

### DIFF
--- a/internal/dialog/input.go
+++ b/internal/dialog/input.go
@@ -3,6 +3,8 @@ package dialog
 import (
 	"image"
 	"image/color"
+	"sync"
+	"time"
 
 	"gioui.org/app"
 	"gioui.org/io/key"
@@ -141,6 +143,13 @@ func (d *inputDialog) Show() (string, bool, error) {
 		app.Title(d.Title),
 		app.Size(unit.Dp(d.Width), unit.Dp(d.Height)),
 	)
+	// TODO work around https://todo.sr.ht/~eliasnaur/gio/602 (still an issue in gio v0.8.0?)
+	// this should only be required shortly after creating the window w.
+	// It doesn't work with the current gio version (0.8.1-dev), which only includes a fix for os_windows.
+	applyWindowOptions := sync.OnceFunc(func() {
+		time.Sleep(50 * time.Millisecond)
+		w.Perform(system.ActionCenter | system.ActionRaise)
+	})
 	w.Perform(system.ActionCenter | system.ActionRaise)
 
 	th := material.NewTheme()
@@ -149,6 +158,7 @@ func (d *inputDialog) Show() (string, bool, error) {
 	for !d.done {
 		switch e := w.Event().(type) {
 		case app.FrameEvent:
+			applyWindowOptions()
 			gtx := app.NewContext(&ops, e)
 			if d.cancelButton.Clicked(gtx) {
 				d.handleCancel()


### PR DESCRIPTION
The fix in 4ec42138521fda408ffdd36ddad0f1ff86d42a9a only worked for Windows, so we re-apply 41f76278692fc7e172e5178efae9442a51e59be6

Relates to https://github.com/gesellix/gioui-dialog/pull/6
